### PR TITLE
Make individual flexible layouts editable

### DIFF
--- a/live-edit-v5.php
+++ b/live-edit-v5.php
@@ -229,6 +229,47 @@ class live_edit {
 		
 		// create form
 		acf_form( $args );
+
+		// find editable flexible layouts
+		$flex_fields = array();
+
+		foreach( $fields as $field ) {
+
+			if( substr( $field, 0, 5 ) === "flex-") {
+
+				$field = str_replace( 'flex-', '', $field );
+				$flex_fields[] = $field;
+			}
+		}
+
+		// remove all other flexible layouts
+		if( !empty( $flex_fields ) )  {
+
+			$flex_fields = json_encode( $flex_fields ); ?>
+
+			<script type="text/javascript">
+				(function($){
+
+					// loop through all flexible layouts loaded in DOM
+					$( 'div.layout' ).each(function(){
+
+
+						var fieldName = $(this).attr('data-layout');
+						
+						// remove layouts not included in editable fields
+						if( $.inArray(fieldName, <?php echo $flex_fields; ?>) == -1 ) {
+							$(this).css({'position':'absolute', 'z-index':'-1'});
+						}
+
+
+					});
+
+				})(jQuery);
+
+			</script>
+
+		<?php }
+
 		
 		
 		if( $options['updated'] === 'true' ) {


### PR DESCRIPTION
Allows users to edit individual flexible layouts. Here is an example of the template code:

live_edit( '{{field-name}}, flex-{{layout-name}}' );

The logic is that first we first specify the flexible content field. We then specify which layouts we want to edit by appending "flex-" before their layout name. So for instance, if I had a flexible content field labeled "page-content" and wanted to edit the layout "hero-section", I would use the following code:

live_edit( 'page-content, flex-hero-section' );

The code basically causes all layouts to load in the panel, but filters through and hides all of the layouts not specified in the template.

Not sure if you had something else in mind to enable this sort of functionality, but it came in handy for one my latest projects.